### PR TITLE
Team: Add animation to sponsor links

### DIFF
--- a/content.css
+++ b/content.css
@@ -167,11 +167,16 @@ h3 {
     width: 14rem;
     height:10rem;
     padding: 1.4rem;
-    opacity: 0.8;
     display: flex;
     justify-content: center;
     align-items: center;
     background-color: var(--color-4);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.team_sponsors_button:hover {
+    transform: scale(1.2);
+    box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
 }
 
 

--- a/team.html
+++ b/team.html
@@ -162,49 +162,49 @@
         <h2>Meet our sponsors</h2>
         <div class="team_sponsors">
 
-            <a href="https://nippongases.com/no-no/" class="team_sponsors_button">
+            <a href="https://nippongases.com/no-no/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Nippon_Gases.png" /></a>
 
-            <a href="https://www.ntnu.no/nv/fakultet-for-naturvitenskap" class="team_sponsors_button">
+            <a href="https://www.ntnu.no/nv/fakultet-for-naturvitenskap" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/NV_fak.svg" /></a>
 
-            <a href="/" class="team_sponsors_button">
+            <a href="/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/logo.png" /></a>
 
-            <a href="https://aquagen.no/" class="team_sponsors_button">
+            <a href="https://aquagen.no/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/AquaGen.png" /></a>
 
-            <a href="https://bmkgenetics.com/" class="team_sponsors_button">
+            <a href="https://bmkgenetics.com/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Benchmark_Gen.png" /></a>
 
-            <a href="https://www.ntnu.no/inb" class="team_sponsors_button">
+            <a href="https://www.ntnu.no/inb" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Inst_nevro.svg" /></a>
 
-            <a href="https://www.tekna.no/" class="team_sponsors_button">
+            <a href="https://www.tekna.no/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Tekna_White.svg" /></a>
 
-            <a href="https://www.ntnu.no/ibt" class="team_sponsors_button">
+            <a href="https://www.ntnu.no/ibt" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Inst_biotek.svg" /></a>
 
-            <a href="https://scaleaq.no/" class="team_sponsors_button">
+            <a href="https://scaleaq.no/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/ScaleAq.png" /></a>
 
-            <a href="https://kvaroyfiskeoppdrett.no/" class="team_sponsors_button">
+            <a href="https://kvaroyfiskeoppdrett.no/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Kvaroy_black.png" /></a>
 
-            <a href="https://www.bergmandiag.no/" class="team_sponsors_button">
+            <a href="https://www.bergmandiag.no/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Bergman Diag.png" /></a>
 
-            <a href="/" class="team_sponsors_button">
+            <a href="/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/logo.png" /></a>
 
-            <a href="https://www.masoval.no/" class="team_sponsors_button">
+            <a href="https://www.masoval.no/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Måsøval.png" /></a>
 
-            <a href="https://www.ntnu.no/biologi" class="team_sponsors_button">
+            <a href="https://www.ntnu.no/biologi" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/Inst_bio.svg" /></a>
 
-            <a href="/" class="team_sponsors_button">
+            <a href="/" target="_blank" class="team_sponsors_button">
                 <img src="Pictures/logo.png" /></a>
 
 


### PR DESCRIPTION
This PR makes the sponsor links in the team site animated. It also opens sponsor links in a new tab, which they should do since they are links to external sites.