### PR TITLE
Team: Add tooltip with firstname for all team member buttons

### DIFF
--- a/content.css
+++ b/content.css
@@ -89,19 +89,13 @@ h3 {
     border: 3px solid var(--color-9);
 }
 
-.team_member_button:hover .team_member_button_tooltip {
-    visibility: initial; /* unsets `visibility: hidden` */
-}
-
-.team_member_button_tooltip {
+.team_member_button::after {
+    content: attr(data-tooltip);
     visibility: hidden;
     position: absolute;
-    top: calc(var(--buttonSize) + 0.5em);
+    top: var(--buttonSize);
     left: 50%; 
-    transform: translateX(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    transform: translateX(-50%) translateY(0.5em);
     padding: 0.3em;
     font-weight: bold;
     background: var(--color-9);
@@ -109,6 +103,9 @@ h3 {
     border-radius: 0.25em;
 }
 
+.team_member_button:hover::after {
+    visibility: initial; /* unsets `visibility: hidden` */
+}
 
 #button_next {
     order:1; /*next button at the end of teamList*/

--- a/content.css
+++ b/content.css
@@ -83,6 +83,7 @@ h3 {
     display:flex;
     align-items: center;
     justify-content: center;
+    opacity:0.6;
     border-radius: 50%;
     margin-right: 0.5rem;
     margin-bottom: 0.5rem;
@@ -108,7 +109,12 @@ h3 {
 }
 
 #button_next {
+    opacity: 1;
     order:1; /*next button at the end of teamList*/
+}
+
+#button_prev {
+    opacity:1;
 }
 
 .team_member_button_image {
@@ -126,7 +132,7 @@ h3 {
 }
 
 .team_member_button:hover {
-    opacity: 0.6;
+    opacity: 1;
     cursor: pointer;
 }
 

--- a/content.css
+++ b/content.css
@@ -75,10 +75,11 @@ h3 {
 }
 
 .team_member_button {
+    --buttonSize: 48px;
     all:unset;
-    width: 48px;
-    height: 48px;
-    overflow: hidden;
+    width: var(--buttonSize);
+    height: var(--buttonSize);
+    position: relative;
     display:flex;
     align-items: center;
     justify-content: center;
@@ -88,11 +89,45 @@ h3 {
     border: 3px solid var(--color-9);
 }
 
+.team_member_button:hover .team_member_button_tooltip {
+    visibility: initial; /* unsets `visibility: hidden` */
+}
+
+.team_member_button_tooltip {
+    visibility: hidden;
+    position: absolute;
+    top: 0;
+    left: 50%; /* center by creating a div inside which overflows */
+    width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translateY(calc(var(--buttonSize) + 0.5em));
+}
+
+.team_member_button_tooltip_content {
+    padding: 0.3em;
+    font-weight: bold;
+    background: var(--color-9);
+    color: var(--color-1);
+    border-radius: 0.25em;
+}
+
 #button_next {
     order:1; /*next button at the end of teamList*/
 }
 
-.team_member_button > * {
+.team_member_button_image {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.team_member_button_image > img {
     width: 110%;
 }
 
@@ -103,6 +138,7 @@ h3 {
 
 .team_member_button_active {
     border: 4px solid var(--color-10);
+    opacity: 1;
 }
 
 .team_member_arrow > img {

--- a/content.css
+++ b/content.css
@@ -96,22 +96,19 @@ h3 {
 .team_member_button_tooltip {
     visibility: hidden;
     position: absolute;
-    top: 0;
-    left: 50%; /* center by creating a div inside which overflows */
-    width: 0;
+    top: calc(var(--buttonSize) + 0.5em);
+    left: 50%; 
+    transform: translateX(-50%);
     display: flex;
     align-items: center;
     justify-content: center;
-    transform: translateY(calc(var(--buttonSize) + 0.5em));
-}
-
-.team_member_button_tooltip_content {
     padding: 0.3em;
     font-weight: bold;
     background: var(--color-9);
     color: var(--color-1);
     border-radius: 0.25em;
 }
+
 
 #button_next {
     order:1; /*next button at the end of teamList*/

--- a/team_list.js
+++ b/team_list.js
@@ -66,10 +66,7 @@ for (const iString in teamList) {
 
     const tooltip = document.createElement("div");
     tooltip.setAttribute("class", "team_member_button_tooltip");
-    const tooltipContent = document.createElement("div");
-    tooltipContent.setAttribute("class", "team_member_button_tooltip_content");
-    tooltipContent.innerHTML = member.name.split(" ")[0]; // First name
-    tooltip.appendChild(tooltipContent);
+    tooltip.innerHTML = member.name.split(" ")[0]; // First name
     button.appendChild(tooltip);
 
     button.onclick = () => {

--- a/team_list.js
+++ b/team_list.js
@@ -53,14 +53,24 @@ for (const iString in teamList) {
 
     const element = document.getElementById("team_list");
     const button = document.createElement("button");
-
     button.setAttribute("class", "team_member_button");
     button.setAttribute("id", "member_button_" + i);
+    
+    const imgContainer = document.createElement("div");
+    imgContainer.setAttribute("class", "team_member_button_image");
+    
     const img = document.createElement("img");
-
     img.setAttribute("src", member.imgUrl);
+    imgContainer.appendChild(img)
+    button.appendChild(imgContainer);
 
-    button.appendChild(img);
+    const tooltip = document.createElement("div");
+    tooltip.setAttribute("class", "team_member_button_tooltip");
+    const tooltipContent = document.createElement("div");
+    tooltipContent.setAttribute("class", "team_member_button_tooltip_content");
+    tooltipContent.innerHTML = member.name.split(" ")[0]; // First name
+    tooltip.appendChild(tooltipContent);
+    button.appendChild(tooltip);
 
     button.onclick = () => {
         updateFields(i)

--- a/team_list.js
+++ b/team_list.js
@@ -55,7 +55,8 @@ for (const iString in teamList) {
     const button = document.createElement("button");
     button.setAttribute("class", "team_member_button");
     button.setAttribute("id", "member_button_" + i);
-    
+    button.setAttribute("data-tooltip", member.name.split(" ")[ 0]) // Fist name
+
     const imgContainer = document.createElement("div");
     imgContainer.setAttribute("class", "team_member_button_image");
     
@@ -63,11 +64,6 @@ for (const iString in teamList) {
     img.setAttribute("src", member.imgUrl);
     imgContainer.appendChild(img)
     button.appendChild(imgContainer);
-
-    const tooltip = document.createElement("div");
-    tooltip.setAttribute("class", "team_member_button_tooltip");
-    tooltip.innerHTML = member.name.split(" ")[0]; // First name
-    button.appendChild(tooltip);
 
     button.onclick = () => {
         updateFields(i)


### PR DESCRIPTION
When hovering over a button for a person in the team member list, the first name of that person is shown as a tooltip below the button as illustrated below:

<img width="878" alt="Screenshot 2021-07-12 at 11 05 30" src="https://user-images.githubusercontent.com/22301657/125260916-144d1300-e301-11eb-88e6-bf459bd172f1.png">

**TODO**: Should probably invert the opacity change, looks a bit weird to decrease the opacity on button when hovered over. Makes more sense to have a decreased opacity on "inactive" elements, and have `opacity: 1` on active and hovered elements. This way it is also a lot clearer which element is active.